### PR TITLE
intersector() overhaul, weighter() upgrading

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -824,6 +824,8 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
   #   print("Somehow the following points were in the SDD and weighted, but had no counterpart in the provided TerrADAT")
   #   print(paste(pointweights.df.merged$PLOTID[!(unique(pointweights.df.merged$PLOTID) %in% unique(pointweights.df.merged$PLOTID))], collapse = ", "))
   # }
+  
+  ## Rename the fields to what we want them to be in the output
   names(pointweights.df)[names(pointweights.df) == "TERRA_TERRADAT_ID"] <- "PRIMARYKEY"
   names(pointweights.df)[names(pointweights.df) == "PLOT_NM"] <- "PLOTID"
   ## Output is a named list with two data frames: information about the strata and information about the points

--- a/functions.R
+++ b/functions.R
@@ -215,8 +215,7 @@ intersector <- function(spdf1, ## A SpatialPolygonsShapefile
                                                   shape2 = spdf2,
                                                   attributefield = spdf2.attributefieldname.input,
                                                   newfield = spdf2.attributefieldname.output)
-  # ## A nonsense separator for paste() to use that we'd never expect in any situation so we can use str_split() later
-  # separator <- "twas_brillig"
+  
   ## Create a single field to serve as a unique identifier to dissolve the polygons by. This concatenates with a known nonsense string so we can split them later
   intersect.spdf.attribute@data$unique.identifier <- sha1(x = paste0(intersect.spdf.attribute@data[, spdf1.attributefieldname.output],
                                                            intersect.spdf.attribute@data[, spdf2.attributefieldname.output]),

--- a/functions.R
+++ b/functions.R
@@ -521,10 +521,8 @@ sdd.reader <- function(src = "", ## A filepath as a string
 }
 
 
-## TODO: Add in using the stratum value table if possible, because that should have the stratum area. Will only work with arcgisbinding :/
 ## This function produces point weights by design stratum (when the SDD contains them) or by sample frame (when it doesn't)
 weighter <- function(sdd.import, ## The output from sdd.reader()
-                     # tdat, ## The TerrADat data frame to use. This lets you throw the whole thing in or slice it down first, if you like
                      reporting.units.spdf = NULL, ## An optional reporting unit SPDF that will be used to clip the SDD import before calculating weights
                      reportingunitfield = "REPORTING.UNIT", ## If passing a reporting unit SPDF, what field in it defines the reporting unit[s]?
                      ## Keywords for point fate—the values in the vectors unknown and nontarget are considered nonresponses.

--- a/functions.R
+++ b/functions.R
@@ -523,6 +523,7 @@ sdd.reader <- function(src = "", ## A filepath as a string
 
 ## This function produces point weights by design stratum (when the SDD contains them) or by sample frame (when it doesn't)
 weighter <- function(sdd.import, ## The output from sdd.reader()
+                     reorder = T, ## Should the SDDs be reordered by size or ar they provided in the order that they should be considered? Depends on how they overlap and user discretion
                      reporting.units.spdf = NULL, ## An optional reporting unit SPDF that will be used to clip the SDD import before calculating weights
                      reportingunitfield = "REPORTING.UNIT", ## If passing a reporting unit SPDF, what field in it defines the reporting unit[s]?
                      ## Keywords for point fate—the values in the vectors unknown and nontarget are considered nonresponses.
@@ -621,11 +622,16 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
     }
   }
   
-  ## Time to reorder that list of SDDs
-  ## Turn the lsit into a vector and then sort it in ascending order
-  sdd.order <- unlist(sdd.order)[sdd.order %>% unlist() %>% sort.list(decreasing = F)]
-  ## Then take the names of the SDDs assigned to those values because we want those, not the areas
-  sdd.order <- names(sdd.order)
+  ## Time to reorder that list of SDDs, if the user wants that, otherwise keep the order that they were fed to sdd.reader() (and therefore appear in sdd.import)
+  if (reorder) {
+    ## Turn the lsit into a vector and then sort it in ascending order
+    sdd.order <- unlist(sdd.order)[sdd.order %>% unlist() %>% sort.list(decreasing = F)]
+    ## Then take the names of the SDDs assigned to those values because we want those, not the areas
+    sdd.order <- names(sdd.order)
+  } else {
+    sdd.order <- names(sdd.order)
+  }
+
   
   ## Initialize our vector of already-considered SDDs which we'll use to work our way out in concentric rings
   sdd.completed <- c()

--- a/functions.R
+++ b/functions.R
@@ -600,8 +600,10 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
       ## Deal with the points
       pts.spdf <- attribute.shapefile(shape1 = pts.spdf,
                                       shape2 = reporting.units.spdf,
-                                      newfield = reportingunitfield,
+                                      newfield = "REPORTING.UNIT.RESTRICTED",
                                       attributefield = reportingunitfield)
+      ## Overwrite whatever value was brought in from the reporting.units.spdf with T because we only want to know if they were restricted or not
+      pts.spdf@data$REPORTING.UNIT.RESTRICTED <- T
       ## Deal with frame.spdf
       frame.spdf <-  attribute.shapefile(shape1 = frame.spdf,
                                          shape2 = reporting.units.spdf,
@@ -651,6 +653,10 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
     
     ## Bring in this SDD's points
     pts.spdf <- sdd.import$pts[[s]]
+    ## Add in the REPORTING.UNITS.RESTRICTED field with the value F if it's not there already. The only way it'd already be there is if the points were restricted
+    if (!("REPORTING.UNIT.RESTRICTED" %in% names(pts.spdf@data))) {
+      pts.spdf@data$REPORTING.UNIT.RESTRICTED <- F
+    }
     
     
     ## Only do this if the user wants the SDDs to be considered as one unit for analysis
@@ -843,7 +849,7 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
   names(pointweights.df)[names(pointweights.df) == "PLOT_NM"] <- "PLOTID"
   ## Output is a named list with two data frames: information about the strata and information about the points
   # return(list(strata.weights = master.df, point.weights = pointweights.df.merged[, c("PRIMARYKEY", "PLOTID", "FINAL_DESIG", "WGT")]))
-  return(list(strata.weights = master.df, point.weights = pointweights.df[, c("PRIMARYKEY", "PLOTID", "FINAL_DESIG", "WGT")]))
+  return(list(strata.weights = master.df, point.weights = pointweights.df[, c("PRIMARYKEY", "PLOTID", "REPORTING.UNIT.RESTRICTED", "FINAL_DESIG", "WGT")]))
 }
 
 # The wgtcats are the unique combinations you get when overlaying design strata and reporting unit

--- a/functions.R
+++ b/functions.R
@@ -653,7 +653,7 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
     
     ## For each SDD that hasn't been considered yet:
     ## Retrieve the points, see if they land in this current frame, keep the ones that do, and write it back into sdd.import without those
-    for (r in sdd.order[!(sdd.order %in% c(sdd.completed, s))]) {
+    for (r in seq_along(sdd.order[!(sdd.order %in% c(sdd.completed, s))])) {
       ## First bring in the points
       pts.spdf.temp <- sdd.import$pts[[r]]
       if (nrow(pts.spdf.temp@data) > 0) {

--- a/functions.R
+++ b/functions.R
@@ -528,7 +528,8 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
                      ## Keywords for point fate—the values in the vectors unknown and nontarget are considered nonresponses.
                      ## Assumes the following keywords are sufficient and consistent.
                      ## "UNK" and "NT" show up in certain SDDs even though the shapefle attributes spell out the keywords and they're invalid??? 
-                     target.values = c("Target Sampled"),
+                     target.values = c("Target Sampled",
+                                       "TS"),
                      unknown.values = c("Unknown",
                                         "UNK"),
                      nontarget.values = c("Non-Target",
@@ -561,7 +562,8 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
   ## The fate values that we know about are hardcoded here.
   ## Whatever values are provided in the function arguments get concatenated and then we keep only the unique values from that result
   target.values <- c(target.values,
-                     "Target Sampled") %>% unique() %>% str_to_upper()
+                     "Target Sampled",
+                     "TS") %>% unique() %>% str_to_upper()
   unknown.values <- c(unknown.values,
                       "Unknown",
                       "UNK") %>% unique() %>% str_to_upper()

--- a/functions.R
+++ b/functions.R
@@ -748,7 +748,11 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
                               Prop.dsgn.pts.obsrvd = Pprop,
                               Sampled.area.HA = Sarea,
                               Weight = wgt,
+                              Reporting.Unit.Restricted = F,
                               stringsAsFactors = F)
+        if (!is.null(reporting.units.spdf)) {
+          temp.df$Reporting.Unit.Restricted <- T
+        }
         ## Bind this stratum's information to the master.df initialized outside and before the loop started
         master.df <- rbind(master.df, temp.df)  ## pile it on.....
         
@@ -793,7 +797,11 @@ weighter <- function(sdd.import, ## The output from sdd.reader()
                             Prop.dsgn.pts.obsrvd = Pprop,
                             Sampled.area.HA = Sarea,
                             Weight = wgt,
+                            Reporting.Unit.Restricted = F,
                             stringsAsFactors = F)
+      if (!is.null(reporting.units.spdf)) {
+        temp.df$Reporting.Unit.Restricted <- T
+      }
       ## Bind this stratum's information to the master.df initialized outside and before the loop started
       master.df <- rbind(master.df, temp.df)  ## pile it on.....
       


### PR DESCRIPTION
Turns out that using raster::intersect() is literally two orders of magnitude faster than using gIntersect()

Added the ability for weighter() to handle a single SDD without a loop crashing using seq_along()
Added weighter() argument reorder to allow user-specified SDD order versus the default ascending by area
Added weighter() argument combine to allow multiple SDDs to be considered independently from one another instead of the default which calculates the weights iteratively as it combines the SDDs